### PR TITLE
Empty resource list

### DIFF
--- a/OpenSim.WebServer.App.Test/Controllers/ResourceWithRelationsTest.cs
+++ b/OpenSim.WebServer.App.Test/Controllers/ResourceWithRelationsTest.cs
@@ -18,7 +18,7 @@ namespace OpenSim.WebServer.App.Test.Controllers
             serverResource.EmbedRelations(CreateFieldsTree(), new EmbeddedRelationsSchema());
 
             // Assert
-            Assert.Equal(2, serverResource.Simulations.Count());
+            Assert.Equal(2, serverResource.Simulations.Count);
             Assert.Equal("Sim1", serverResource.Simulations.ElementAt(0).Name);
             Assert.Equal("Sim2", serverResource.Simulations.ElementAt(1).Name);
             Assert.Equal("User", serverResource.Author.Name);

--- a/OpenSim.WebServer.App/ClientApp/app/components/servers/servers.component.html
+++ b/OpenSim.WebServer.App/ClientApp/app/components/servers/servers.component.html
@@ -22,6 +22,6 @@
         </div>
     </div>
     
-    <new-server-form id="new-server-form" (serverCreated)="onServerCreated($event)"></new-server-form>
+    <!--<new-server-form id="new-server-form" (serverCreated)="onServerCreated($event)"></new-server-form>-->
 </div>
 

--- a/OpenSim.WebServer.App/ClientApp/app/components/servers/servers.component.html
+++ b/OpenSim.WebServer.App/ClientApp/app/components/servers/servers.component.html
@@ -22,6 +22,6 @@
         </div>
     </div>
     
-    <!--<new-server-form id="new-server-form" (serverCreated)="onServerCreated($event)"></new-server-form>-->
+    <new-server-form id="new-server-form" (serverCreated)="onServerCreated($event)"></new-server-form>
 </div>
 

--- a/OpenSim.WebServer.App/ClientApp/app/model/embedding-resource.ts
+++ b/OpenSim.WebServer.App/ClientApp/app/model/embedding-resource.ts
@@ -11,11 +11,6 @@ export abstract  class EmbeddingResource extends Resource {
     public id?: number;
     protected _embedded: any = new Object();
 
-    // TODO: current back end hateoas implementations doesn't send null and empty list resources
-    // we need to know if we requested resource and it's null/empty array or we haven't requested yet
-    // and it's still possible yet to have one extra request in case of empty collection
-    private queriedRelations = new Set<string>(); 
-
     private get isLocal(): boolean { return this.id == undefined; }
 
     protected getOrQueryResource<T extends Resource>(
@@ -30,12 +25,7 @@ export abstract  class EmbeddingResource extends Resource {
         if (this.isLocal || value != undefined)
             return new ValueAndStream(value, of(value));
 
-        if (this.queriedRelations.has(relation))
-            return new ValueAndStream(undefined, of(undefined));
-
-        this.queriedRelations.add(relation);
-
-        const  stream = this.getRelation(type, relation);
+        const stream = this.getRelation(type, relation);
         stream.subscribe(res => setter(res));
         return new ValueAndStream<T | undefined>(undefined, stream);
     }
@@ -51,12 +41,6 @@ export abstract  class EmbeddingResource extends Resource {
 
         if (this.isLocal || value != undefined)
             return new ValueAndStream(value, of(value));
-
-        // waiting for response yet
-        if (this.queriedRelations.has(relation))
-            return new ValueAndStream([], of([]));
-
-        this.queriedRelations.add(relation);
 
         const stream = this.getRelationArray(type, relation);
         stream.subscribe(res => setter(res));

--- a/OpenSim.WebServer.App/ClientApp/app/model/embedding-resource.ts
+++ b/OpenSim.WebServer.App/ClientApp/app/model/embedding-resource.ts
@@ -31,10 +31,12 @@ export abstract  class EmbeddingResource extends Resource {
             return new ValueAndStream(undefined, this.queriedRelations[relation] as Observable<T | undefined>);
 
         const stream = this.getRelation(type, relation);
+
         stream.subscribe(res => {
             setter(res);
             delete this.queriedRelations[relation];
         });
+
         this.queriedRelations[relation] = stream;
         return new ValueAndStream<T | undefined>(undefined, stream);
     }

--- a/OpenSim.WebServer.App/ClientApp/app/model/embedding-resource.ts
+++ b/OpenSim.WebServer.App/ClientApp/app/model/embedding-resource.ts
@@ -31,7 +31,10 @@ export abstract  class EmbeddingResource extends Resource {
             return new ValueAndStream(undefined, this.queriedRelations[relation] as Observable<T | undefined>);
 
         const stream = this.getRelation(type, relation);
-        stream.subscribe(res => setter(res));
+        stream.subscribe(res => {
+            setter(res);
+            delete this.queriedRelations[relation];
+        });
         this.queriedRelations[relation] = stream;
         return new ValueAndStream<T | undefined>(undefined, stream);
     }
@@ -52,7 +55,12 @@ export abstract  class EmbeddingResource extends Resource {
             return new ValueAndStream([], this.queriedRelations[relation] as Observable<T[]>);
 
         const stream = this.getRelationArray(type, relation);
-        stream.subscribe(res => setter(res));
+
+        stream.subscribe(res => {
+            setter(res);
+            delete this.queriedRelations[relation];
+        });
+
         this.queriedRelations[relation] = stream;
         return new ValueAndStream([], stream);
     }

--- a/OpenSim.WebServer.App/Controllers/ResourceWithRelationsExtension.cs
+++ b/OpenSim.WebServer.App/Controllers/ResourceWithRelationsExtension.cs
@@ -24,7 +24,8 @@ namespace OpenSim.WebServer.Controllers
             where T : IResourceWithRelations
         {
             var fields = request.GetFieldsDefinition();
-            var embeddedField = fields.FirstOrDefault()?.Nodes.GetEmbeddedFieldNode();
+            var collectionNode = fields.FirstOrDefault()?.Nodes.Single();
+            var embeddedField = collectionNode?.Nodes.GetEmbeddedFieldNode();
             if (embeddedField == null)
                 return resources;
 

--- a/OpenSim.WebServer.App/Controllers/Server/ServerEmbeddedRelationSchema.cs
+++ b/OpenSim.WebServer.App/Controllers/Server/ServerEmbeddedRelationSchema.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using OpenSim.WebServer.Model;
+using WebApi.Hal;
 
 namespace OpenSim.WebServer.Controllers
 {
@@ -9,10 +10,14 @@ namespace OpenSim.WebServer.Controllers
         {
             RegisterEmbeddedRelation("author",
                 (resource, model) => resource.Author = new UserInfoResource(model.Author) { Rel = "author" });
+
             RegisterEmbeddedRelation("simulations", 
-                (resource, model) => resource.Simulations = model.Simulations?.Select(s => new SimulationResource(s)).ToList());
-            RegisterEmbeddedRelation("presentations", 
-                (resource, model) => resource.Presentations = model.Presentations?.Select(p => new PresentationResource(p)).ToList());
+                (resource, model) => resource.Simulations =
+                    new ResourceList<SimulationResource>(LinkTemplates.Servers.GetSimulations.Rel, model.Simulations?.Select(s => new SimulationResource(s))));
+
+            RegisterEmbeddedRelation(LinkTemplates.Servers.GetPresentations.Rel, 
+                (resource, model) => resource.Presentations = 
+                    new ResourceList<PresentationResource>(LinkTemplates.Servers.GetPresentations.Rel, model.Presentations?.Select(p => new PresentationResource(p))));
         }
     }
 }

--- a/OpenSim.WebServer.App/Controllers/Server/ServerEmbeddedRelationSchema.cs
+++ b/OpenSim.WebServer.App/Controllers/Server/ServerEmbeddedRelationSchema.cs
@@ -8,16 +8,18 @@ namespace OpenSim.WebServer.Controllers
     {
         public ServerEmbeddedRelationSchema()
         {
-            RegisterEmbeddedRelation("author",
-                (resource, model) => resource.Author = new UserInfoResource(model.Author) { Rel = "author" });
+            RegisterEmbeddedRelation(LinkTemplates.Servers.Author.Rel,
+                (resource, model) => resource.Author = new UserInfoResource(model.Author) { Rel = LinkTemplates.Servers.Author.Rel });
 
-            RegisterEmbeddedRelation("simulations", 
+            RegisterEmbeddedRelation(LinkTemplates.Servers.GetSimulations.Rel, 
                 (resource, model) => resource.Simulations =
-                    new ResourceList<SimulationResource>(LinkTemplates.Servers.GetSimulations.Rel, model.Simulations?.Select(s => new SimulationResource(s))));
+                    new ResourceList<SimulationResource>(LinkTemplates.Servers.GetSimulations.Rel, 
+                        model.Simulations?.Select(s => new SimulationResource(s)) ?? Enumerable.Empty<SimulationResource>()));
 
             RegisterEmbeddedRelation(LinkTemplates.Servers.GetPresentations.Rel, 
                 (resource, model) => resource.Presentations = 
-                    new ResourceList<PresentationResource>(LinkTemplates.Servers.GetPresentations.Rel, model.Presentations?.Select(p => new PresentationResource(p))));
+                    new ResourceList<PresentationResource>(LinkTemplates.Servers.GetPresentations.Rel, 
+                        model.Presentations?.Select(p => new PresentationResource(p)) ?? Enumerable.Empty<PresentationResource>()));
         }
     }
 }

--- a/OpenSim.WebServer.App/Controllers/Server/ServerResource.cs
+++ b/OpenSim.WebServer.App/Controllers/Server/ServerResource.cs
@@ -31,12 +31,8 @@ namespace OpenSim.WebServer.Controllers
         public bool IsCustomUiAvailable { get; set; }
 
         public UserInfoResource Author { get; set; }
-
-        public IResourceList Simulations { get; set; } = 
-            new ResourceList<SimulationResource>(LinkTemplates.Servers.GetSimulations.Rel);
-
-        public IResourceList Presentations { get; set; } = 
-            new ResourceList<PresentationResource>(LinkTemplates.Servers.GetPresentations.Rel);
+        public ResourceList<SimulationResource> Simulations { get; set; }
+        public ResourceList<PresentationResource> Presentations { get; set; }
     
         public override void EmbedRelations(FieldsTreeNode embeddedFieldNode, IEmbeddedRelationsSchema schema) =>
             EmbedRelations(embeddedFieldNode, schema, schema.Server);

--- a/OpenSim.WebServer.App/Controllers/Server/ServerResource.cs
+++ b/OpenSim.WebServer.App/Controllers/Server/ServerResource.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using OpenSim.WebServer.App.Controllers;
 using OpenSim.WebServer.Model;
+using WebApi.Hal;
 
 namespace OpenSim.WebServer.Controllers
 {
@@ -31,9 +31,13 @@ namespace OpenSim.WebServer.Controllers
         public bool IsCustomUiAvailable { get; set; }
 
         public UserInfoResource Author { get; set; }
-        public IEnumerable<SimulationResource> Simulations { get; set; }
-        public IEnumerable<PresentationResource> Presentations { get; set; } = Enumerable.Empty<PresentationResource>();
 
+        public IResourceList Simulations { get; set; } = 
+            new ResourceList<SimulationResource>(LinkTemplates.Servers.GetSimulations.Rel);
+
+        public IResourceList Presentations { get; set; } = 
+            new ResourceList<PresentationResource>(LinkTemplates.Servers.GetPresentations.Rel);
+    
         public override void EmbedRelations(FieldsTreeNode embeddedFieldNode, IEmbeddedRelationsSchema schema) =>
             EmbedRelations(embeddedFieldNode, schema, schema.Server);
 


### PR DESCRIPTION
Support for WebApi Hal capability to return named empty collection
This is used to understand if collection is really empty during laze loading of missed relations. 